### PR TITLE
Fix examples compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,6 @@ name = "completion-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-client",
  "serde",
  "serde_json",
@@ -92,7 +91,6 @@ name = "completion-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-server",
  "serde",
  "serde_json",
@@ -201,7 +199,6 @@ name = "hello-world"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-server",
  "serde",
  "serde_json",
@@ -397,9 +394,7 @@ name = "prompt-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-client",
- "modelcontextprotocol-server",
  "serde_json",
  "tokio",
  "tracing",
@@ -411,8 +406,6 @@ name = "prompt-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
- "modelcontextprotocol-client",
  "modelcontextprotocol-server",
  "serde_json",
  "tokio",
@@ -443,7 +436,6 @@ name = "resource-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-server",
  "serde_json",
  "tokio",
@@ -470,7 +462,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-client",
  "serde_json",
  "tokio",
@@ -485,7 +476,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-server",
  "serde_json",
  "tokio",
@@ -554,7 +544,6 @@ name = "simple-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-client",
  "serde",
  "serde_json",
@@ -604,7 +593,6 @@ name = "template-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-client",
  "serde_json",
  "tokio",
@@ -617,7 +605,6 @@ name = "template-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "mcp-protocol 0.2.2",
  "modelcontextprotocol-server",
  "serde_json",
  "tokio",

--- a/examples/completion-client/Cargo.toml
+++ b/examples/completion-client/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-client = { path = "../../mcp-client" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/completion-client/src/main.rs
+++ b/examples/completion-client/src/main.rs
@@ -1,10 +1,12 @@
-use std::sync::Arc;
 use anyhow::Result;
-use mcp_client::{ClientBuilder, transport::StdioTransport};
-use mcp_protocol::types::completion::{CompletionReference, CompletionArgument, CompleteRequest};
-use tracing::{info, Level};
+use modelcontextprotocol_client::mcp_protocol::types::completion::{
+    CompleteRequest, CompletionArgument, CompletionReference,
+};
+use modelcontextprotocol_client::{transport::StdioTransport, ClientBuilder};
 use std::fs::OpenOptions;
 use std::io;
+use std::sync::Arc;
+use tracing::{info, Level};
 use tracing_subscriber::fmt;
 
 #[tokio::main]
@@ -13,29 +15,33 @@ async fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .with_writer(move || -> Box<dyn io::Write> {
-            Box::new(io::BufWriter::new(OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("completion-client.log")
-                .unwrap()))
+            Box::new(io::BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("completion-client.log")
+                    .unwrap(),
+            ))
         })
         .with_ansi(true) // Enable ANSI color codes
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set default tracing subscriber");
-    
+
     info!("Starting completion client");
-    
+
     // Path to the server executable
     let server_path = "../../target/debug/completion-server";
-    
+
     // Create and connect to server
     let (transport, mut receiver) = StdioTransport::new(server_path, vec![]);
-    
-    let client = Arc::new(ClientBuilder::new("completion-client", "0.1.0")
-        .with_transport(transport)
-        .build()?);
-    
+
+    let client = Arc::new(
+        ClientBuilder::new("completion-client", "0.1.0")
+            .with_transport(transport)
+            .build()?,
+    );
+
     // Start message handling
     let client_for_handler = client.clone();
     tokio::spawn(async move {
@@ -47,12 +53,15 @@ async fn main() -> Result<()> {
             }
         }
     });
-    
+
     // Initialize the client
     info!("Initializing connection to server");
     let init_result = client.initialize().await?;
-    info!("Connected to: {} v{}", init_result.server_info.name, init_result.server_info.version);
-    
+    info!(
+        "Connected to: {} v{}",
+        init_result.server_info.name, init_result.server_info.version
+    );
+
     // Get available resource templates
     info!("Requesting resource templates");
     let templates_result = client.list_resource_templates().await?;
@@ -64,10 +73,10 @@ async fn main() -> Result<()> {
             info!("Template: {} - {}", template.uri_template, template.name);
         }
     }
-    
+
     // Try completion for the file template
     let template_uri = "file:///{project}/{filename}";
-    
+
     // First, try completion for the 'project' parameter
     info!("Requesting completion for 'project' parameter");
     let project_completion_request = CompleteRequest {
@@ -76,16 +85,16 @@ async fn main() -> Result<()> {
         },
         argument: CompletionArgument {
             name: "project".to_string(),
-            value: "b".to_string(),  // Should match 'backend'
+            value: "b".to_string(), // Should match 'backend'
         },
     };
-    
+
     let project_completion = client.complete(project_completion_request).await?;
     info!("Project completion results:");
     for value in &project_completion.completion.values {
         info!("  - {}", value);
     }
-    
+
     // Then, try completion for the 'filename' parameter
     info!("Requesting completion for 'filename' parameter");
     let filename_completion_request = CompleteRequest {
@@ -94,16 +103,16 @@ async fn main() -> Result<()> {
         },
         argument: CompletionArgument {
             name: "filename".to_string(),
-            value: "m".to_string(),  // Should match 'main.rs' etc.
+            value: "m".to_string(), // Should match 'main.rs' etc.
         },
     };
-    
+
     let filename_completion = client.complete(filename_completion_request).await?;
     info!("Filename completion results:");
     for value in &filename_completion.completion.values {
         info!("  - {}", value);
     }
-    
+
     // Now try completion for a prompt parameter
     info!("Requesting completion for 'language' parameter in prompt");
     let prompt_completion_request = CompleteRequest {
@@ -115,7 +124,7 @@ async fn main() -> Result<()> {
             value: "py".to_string(),
         },
     };
-    
+
     let prompt_completion = client.complete(prompt_completion_request).await?;
     info!("Prompt parameter completion results:");
     if prompt_completion.completion.values.is_empty() {
@@ -125,10 +134,10 @@ async fn main() -> Result<()> {
             info!("  - {}", value);
         }
     }
-    
+
     // Shutdown
     info!("Shutting down client");
     client.shutdown().await?;
-    
+
     Ok(())
 }

--- a/examples/completion-server/Cargo.toml
+++ b/examples/completion-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-server = { path = "../../mcp-server" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/completion-server/src/main.rs
+++ b/examples/completion-server/src/main.rs
@@ -1,16 +1,14 @@
 use anyhow::Result;
-use mcp_protocol::{
-    types::{
-        resource::{Resource, ResourceTemplate},
-        completion::CompletionItem,
-        prompt::{Prompt, PromptArgument, PromptMessage, PromptMessageContent},
-    }
+use modelcontextprotocol_server::mcp_protocol::types::{
+    completion::CompletionItem,
+    prompt::{Prompt, PromptArgument, PromptMessage, PromptMessageContent},
+    resource::{Resource, ResourceTemplate},
 };
-use mcp_server::{ServerBuilder, transport::StdioTransport};
+use modelcontextprotocol_server::{transport::StdioTransport, ServerBuilder};
 use std::fs::OpenOptions;
 use std::io;
 use std::sync::Arc;
-use tracing::{info, debug, Level};
+use tracing::{debug, info, Level};
 use tracing_subscriber::fmt;
 
 #[tokio::main]
@@ -19,31 +17,33 @@ async fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .with_writer(move || -> Box<dyn io::Write> {
-            Box::new(io::BufWriter::new(OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("completion-server.log")
-                .unwrap()))
+            Box::new(io::BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("completion-server.log")
+                    .unwrap(),
+            ))
         })
         .with_ansi(true) // Enable ANSI color codes
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set default tracing subscriber");
-    
+
     debug!("Logging initialized");
-    
+
     info!("Starting completion-server MCP server");
-    
+
     debug!("Initializing server");
-    
+
     // Create server with stdio transport
-    let mut server_builder = ServerBuilder::new("completion-server", "0.1.0")
-        .with_transport(StdioTransport::new());
-    
+    let mut server_builder =
+        ServerBuilder::new("completion-server", "0.1.0").with_transport(StdioTransport::new());
+
     // Create a resource manager
-    let resource_manager = Arc::new(mcp_server::resources::ResourceManager::new());
+    let resource_manager = Arc::new(modelcontextprotocol_server::resources::ResourceManager::new());
     server_builder = server_builder.with_resource_manager(resource_manager.clone());
-    
+
     // Register a file URI template with completions
     let template = ResourceTemplate {
         uri_template: "file:///{project}/{filename}".to_string(),
@@ -52,82 +52,92 @@ async fn main() -> Result<()> {
         mime_type: Some("application/octet-stream".to_string()),
         annotations: None,
     };
-    
+
     // Register template with a simple expander
     resource_manager.register_template(template.clone(), |template_uri, params| {
         let mut result = template_uri;
-        
+
         for (name, value) in params {
             result = result.replace(&format!("{{{}}}", name), &value);
         }
-        
+
         Ok(result)
     });
-    
+
     // Register completion provider for the template
-    resource_manager.register_completion_provider(&template.uri_template, move |_, param_name, value| {
-        debug!("Getting completions for parameter: {} with value: {:?}", param_name, value);
-        
-        match param_name.as_str() {
-            "project" => {
-                // Provide a list of example projects
-                let projects = vec!["backend", "frontend", "common", "tools", "docs"];
-                
-                let filtered = if let Some(prefix) = value {
-                    projects.into_iter()
-                        .filter(|p| p.starts_with(&prefix))
-                        .collect::<Vec<&str>>()
-                } else {
-                    projects
-                };
-                
-                let items = filtered.into_iter()
-                    .map(|p| CompletionItem {
-                        label: p.to_string(),
-                        detail: Some(format!("Project directory: {}", p)),
-                        documentation: None,
-                    })
-                    .collect();
-                
-                Ok(items)
-            },
-            "filename" => {
-                // Provide some example filenames based on the project
-                let filenames = match value {
-                    Some(val) if val.starts_with("main") => {
-                        vec!["main.rs", "main.go", "main.py", "main.js"]
-                    },
-                    Some(val) if val.starts_with("config") => {
-                        vec!["config.json", "config.yaml", "config.toml"]
-                    },
-                    Some(val) => {
-                        // Filter by prefix
-                        vec!["api.rs", "utils.rs", "models.rs", "config.rs", "main.rs"].into_iter()
-                            .filter(|f| f.starts_with(&val))
-                            .collect()
-                    },
-                    None => {
-                        vec!["api.rs", "utils.rs", "models.rs", "config.rs", "main.rs"]
-                    }
-                };
-                
-                let items = filenames.into_iter()
-                    .map(|f| CompletionItem {
-                        label: f.to_string(),
-                        detail: Some(format!("File: {}", f)),
-                        documentation: None,
-                    })
-                    .collect();
-                
-                Ok(items)
-            },
-            _ => {
-                // Unknown parameter
-                Ok(vec![])
+    resource_manager.register_completion_provider(
+        &template.uri_template,
+        move |_, param_name, value| {
+            debug!(
+                "Getting completions for parameter: {} with value: {:?}",
+                param_name, value
+            );
+
+            match param_name.as_str() {
+                "project" => {
+                    // Provide a list of example projects
+                    let projects = vec!["backend", "frontend", "common", "tools", "docs"];
+
+                    let filtered = if let Some(prefix) = value {
+                        projects
+                            .into_iter()
+                            .filter(|p| p.starts_with(&prefix))
+                            .collect::<Vec<&str>>()
+                    } else {
+                        projects
+                    };
+
+                    let items = filtered
+                        .into_iter()
+                        .map(|p| CompletionItem {
+                            label: p.to_string(),
+                            detail: Some(format!("Project directory: {}", p)),
+                            documentation: None,
+                        })
+                        .collect();
+
+                    Ok(items)
+                }
+                "filename" => {
+                    // Provide some example filenames based on the project
+                    let filenames = match value {
+                        Some(val) if val.starts_with("main") => {
+                            vec!["main.rs", "main.go", "main.py", "main.js"]
+                        }
+                        Some(val) if val.starts_with("config") => {
+                            vec!["config.json", "config.yaml", "config.toml"]
+                        }
+                        Some(val) => {
+                            // Filter by prefix
+                            vec!["api.rs", "utils.rs", "models.rs", "config.rs", "main.rs"]
+                                .into_iter()
+                                .filter(|f| f.starts_with(&val))
+                                .collect()
+                        }
+                        None => {
+                            vec!["api.rs", "utils.rs", "models.rs", "config.rs", "main.rs"]
+                        }
+                    };
+
+                    let items = filenames
+                        .into_iter()
+                        .map(|f| CompletionItem {
+                            label: f.to_string(),
+                            detail: Some(format!("File: {}", f)),
+                            documentation: None,
+                        })
+                        .collect();
+
+                    Ok(items)
+                }
+                _ => {
+                    // Unknown parameter
+                    Ok(vec![])
+                }
             }
-        }
-    });
-    
+        },
+    );
+
     // Register a simple resource
     let resource = Resource {
         uri: "file:///backend/main.rs".to_string(),
@@ -137,9 +147,9 @@ async fn main() -> Result<()> {
         annotations: None,
         size: None,
     };
-    
+
     resource_manager.register_resource(resource, || {
-        let content = mcp_protocol::types::resource::ResourceContent {
+        let content = modelcontextprotocol_server::mcp_protocol::types::resource::ResourceContent {
             uri: "file:///backend/main.rs".to_string(),
             mime_type: "text/x-rust".to_string(),
             text: Some("fn main() {\n    println!(\"Hello from the backend!\");\n}".to_string()),
@@ -147,11 +157,11 @@ async fn main() -> Result<()> {
         };
         Ok(vec![content])
     });
-    
+
     // Also register a prompt with parameters for completion
-    let prompt_manager = Arc::new(mcp_server::prompts::PromptManager::new());
+    let prompt_manager = Arc::new(modelcontextprotocol_server::prompts::PromptManager::new());
     server_builder = server_builder.with_prompt_manager(prompt_manager.clone());
-    
+
     // Create a prompt
     let prompt = Prompt {
         name: "code_review".to_string(),
@@ -166,75 +176,74 @@ async fn main() -> Result<()> {
                 name: "focus".to_string(),
                 description: Some("Review focus area".to_string()),
                 required: Some(false),
-            }
+            },
         ]),
         annotations: None,
     };
-    
+
     // Register the prompt
     prompt_manager.register_prompt(prompt, |params| {
-        let language = params.as_ref()
+        let language = params
+            .as_ref()
             .and_then(|p| p.get("language"))
             .cloned()
             .unwrap_or_else(|| "unknown".to_string());
-            
-        let focus = params.as_ref()
+
+        let focus = params
+            .as_ref()
             .and_then(|p| p.get("focus"))
             .cloned()
             .unwrap_or_else(|| "general".to_string());
-        
+
         let message = PromptMessage {
             role: "system".to_string(),
-            content: PromptMessageContent::Text { 
-                text: format!("Reviewing {} code with focus on {}", language, focus)
+            content: PromptMessageContent::Text {
+                text: format!("Reviewing {} code with focus on {}", language, focus),
             },
         };
-        
+
         Ok(vec![message])
     });
-    
+
     // Register language completion provider for the prompt
-    prompt_manager.register_completion_provider(
-        "code_review",
-        "language",
-        |_, prefix| {
-            let languages = vec![
-                "python".to_string(), 
-                "javascript".to_string(), 
-                "typescript".to_string(), 
-                "rust".to_string(), 
-                "go".to_string(), 
-                "java".to_string(), 
-                "c#".to_string(), 
-                "c++".to_string(), 
-                "php".to_string(), 
-                "ruby".to_string(), 
-                "kotlin".to_string(), 
-                "swift".to_string()
-            ];
-            
-            let filtered_langs = if let Some(prefix) = prefix {
-                languages.into_iter()
-                    .filter(|lang| lang.starts_with(&prefix.to_lowercase()))
-                    .collect()
-            } else {
-                languages
-            };
-            
-            Ok(filtered_langs)
-        }
-    );
-    
+    prompt_manager.register_completion_provider("code_review", "language", |_, prefix| {
+        let languages = vec![
+            "python".to_string(),
+            "javascript".to_string(),
+            "typescript".to_string(),
+            "rust".to_string(),
+            "go".to_string(),
+            "java".to_string(),
+            "c#".to_string(),
+            "c++".to_string(),
+            "php".to_string(),
+            "ruby".to_string(),
+            "kotlin".to_string(),
+            "swift".to_string(),
+        ];
+
+        let filtered_langs = if let Some(prefix) = prefix {
+            languages
+                .into_iter()
+                .filter(|lang| lang.starts_with(&prefix.to_lowercase()))
+                .collect()
+        } else {
+            languages
+        };
+
+        Ok(filtered_langs)
+    });
+
     // Build the server
     let server = server_builder.build()?;
-    
+
     info!("Server initialized. Waiting for client connection...");
-    
+
     debug!("Starting server run loop");
     // Run server (blocks until shutdown)
     server.run().await?;
-    
+
     info!("Server shutting down");
-    
+
     Ok(())
 }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-server = { path = "../../mcp-server" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,37 +1,39 @@
 use anyhow::Result;
-use mcp_protocol::types::tool::{ToolCallResult, ToolContent};
-use mcp_server::{ServerBuilder, transport::StdioTransport};
+use modelcontextprotocol_server::mcp_protocol::types::tool::{ToolCallResult, ToolContent};
+use modelcontextprotocol_server::{transport::StdioTransport, ServerBuilder};
 use serde_json::json;
-use tracing::{info, debug, Level};
 use std::fs::OpenOptions;
-use tracing_subscriber::fmt;
 use std::io;
+use tracing::{debug, info, Level};
+use tracing_subscriber::fmt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging to a file
-    
+
     // Setup subscriber with file writer - no ANSI colors for file
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .with_writer(move || -> Box<dyn io::Write> {
-            Box::new(io::BufWriter::new(OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("hello-server.log")
-                .unwrap()))
+            Box::new(io::BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("hello-server.log")
+                    .unwrap(),
+            ))
         })
         .with_ansi(true) // Enable ANSI color codes
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set default tracing subscriber");
-    
+
     debug!("Logging initialized");
-    
+
     info!("Starting hello-world MCP server");
-    
+
     debug!("Initializing server");
-    
+
     // Create server with stdio transport
     let server = ServerBuilder::new("hello-world", "0.1.0")
         .with_transport(StdioTransport::new())
@@ -50,34 +52,30 @@ async fn main() -> Result<()> {
             }),
             |args| {
                 debug!("Hello tool called with args: {:?}", args);
-                
-                let name = args.get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("world");
-                
+
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("world");
+
                 debug!("Greeting {}", name);
-                
-                let content = vec![
-                    ToolContent::Text {
-                        text: format!("Hello, {}!", name)
-                    }
-                ];
-                
+
+                let content = vec![ToolContent::Text {
+                    text: format!("Hello, {}!", name),
+                }];
+
                 Ok(ToolCallResult {
                     content,
-                    is_error: Some(false)
+                    is_error: Some(false),
                 })
-            }
+            },
         )
         .build()?;
-    
+
     info!("Server initialized. Waiting for client connection...");
-    
+
     debug!("Starting server run loop");
     // Run server (blocks until shutdown)
     server.run().await?;
-    
+
     info!("Server shutting down");
-    
+
     Ok(())
 }

--- a/examples/prompt-client/Cargo.toml
+++ b/examples/prompt-client/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
-modelcontextprotocol-server = { path = "../../mcp-server" }
 modelcontextprotocol-client = { path = "../../mcp-client" }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/examples/prompt-server/Cargo.toml
+++ b/examples/prompt-server/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-server = { path = "../../mcp-server" }
-modelcontextprotocol-client = { path = "../../mcp-client" }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/examples/resource-server/Cargo.toml
+++ b/examples/resource-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-server = { path = "../../mcp-server" }
 tokio = { version = "1.28", features = ["full"] }
 anyhow = "1.0"

--- a/examples/sampling-client/Cargo.toml
+++ b/examples/sampling-client/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 modelcontextprotocol-client = { path = "../../mcp-client" }
-mcp-protocol = { path = "../../mcp-protocol" }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/sampling-client/src/main.rs
+++ b/examples/sampling-client/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use mcp_client::{ClientBuilder, transport::StdioTransport};
-use mcp_protocol::types::sampling::{CreateMessageResult, MessageContent};
+use modelcontextprotocol_client::mcp_protocol::types::sampling::{
+    CreateMessageResult, MessageContent,
+};
+use modelcontextprotocol_client::{transport::StdioTransport, ClientBuilder};
 use tracing::{info, Level};
 use tracing_subscriber::fmt;
 
@@ -10,47 +12,58 @@ async fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .finish();
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("Failed to set default subscriber");
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set default subscriber");
 
     // Create client using the builder
     let client = ClientBuilder::new("sampling-client-example", "0.1.0")
         .with_sampling() // Enable sampling capability
-        .with_transport(StdioTransport::new("cargo", vec!["run".to_string(), "--package".to_string(), "sampling-server".to_string()]).0)
+        .with_transport(
+            StdioTransport::new(
+                "cargo",
+                vec![
+                    "run".to_string(),
+                    "--package".to_string(),
+                    "sampling-server".to_string(),
+                ],
+            )
+            .0,
+        )
         .build()?;
 
     // Register sampling callback
-    client.register_sampling_callback(Box::new(|params| {
-        info!("Received sampling request: {:?}", params);
-        
-        // In a real implementation, this would call an actual LLM API
-        // For this example, we just echo back the user's message
-        
-        let mut response_text = String::from("You said: ");
-        
-        // Find the last user message content
-        for message in &params.messages {
-            if message.role == "user" {
-                if let MessageContent::Text { text } = &message.content {
-                    response_text.push_str(text);
-                    break;
+    client
+        .register_sampling_callback(Box::new(|params| {
+            info!("Received sampling request: {:?}", params);
+
+            // In a real implementation, this would call an actual LLM API
+            // For this example, we just echo back the user's message
+
+            let mut response_text = String::from("You said: ");
+
+            // Find the last user message content
+            for message in &params.messages {
+                if message.role == "user" {
+                    if let MessageContent::Text { text } = &message.content {
+                        response_text.push_str(text);
+                        break;
+                    }
                 }
             }
-        }
-        
-        // Create response
-        let result = CreateMessageResult {
-            role: "assistant".to_string(),
-            content: MessageContent::Text {
-                text: response_text
-            },
-            model: Some("echo-model-1.0".to_string()),
-            stop_reason: Some("content_length".to_string()),
-            metadata: None,
-        };
-        
-        Ok(result)
-    })).await?;
+
+            // Create response
+            let result = CreateMessageResult {
+                role: "assistant".to_string(),
+                content: MessageContent::Text {
+                    text: response_text,
+                },
+                model: Some("echo-model-1.0".to_string()),
+                stop_reason: Some("content_length".to_string()),
+                metadata: None,
+            };
+
+            Ok(result)
+        }))
+        .await?;
 
     // Connect to server
     info!("Connecting to server...");
@@ -59,7 +72,7 @@ async fn main() -> Result<()> {
 
     // Wait for requests from the server
     info!("Waiting for sampling requests...");
-    
+
     // In a real implementation, we would have a proper message loop
     // For this example, we'll just sleep and wait for requests
     loop {

--- a/examples/sampling-server/Cargo.toml
+++ b/examples/sampling-server/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 modelcontextprotocol-server = { path = "../../mcp-server" }
-mcp-protocol = { path = "../../mcp-protocol" }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/sampling-server/src/main.rs
+++ b/examples/sampling-server/src/main.rs
@@ -1,14 +1,10 @@
 use anyhow::Result;
-use mcp_protocol::{
-    types::{
-        tool::{ToolCallResult, ToolContent}
-    }
-};
-use mcp_server::{ServerBuilder, transport::StdioTransport};
+use modelcontextprotocol_server::mcp_protocol::types::tool::{ToolCallResult, ToolContent};
+use modelcontextprotocol_server::{transport::StdioTransport, ServerBuilder};
 use serde_json::json;
 use std::fs::OpenOptions;
 use std::io;
-use tracing::{info, debug, Level};
+use tracing::{debug, info, Level};
 use tracing_subscriber::fmt;
 
 #[tokio::main]
@@ -17,23 +13,25 @@ async fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .with_writer(move || -> Box<dyn io::Write> {
-            Box::new(io::BufWriter::new(OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("sampling-server.log")
-                .unwrap()))
+            Box::new(io::BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("sampling-server.log")
+                    .unwrap(),
+            ))
         })
         .with_ansi(true) // Enable ANSI color codes
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set default tracing subscriber");
-    
+
     debug!("Logging initialized");
-    
+
     info!("Starting sampling-server MCP server");
-    
+
     debug!("Initializing server");
-    
+
     // Create server with stdio transport
     let server = ServerBuilder::new("sampling-server", "0.1.0")
         .with_transport(StdioTransport::new())
@@ -53,11 +51,12 @@ async fn main() -> Result<()> {
             }),
             |args| {
                 debug!("Ask LLM tool called with args: {:?}", args);
-                
-                let question = args.get("question")
+
+                let question = args
+                    .get("question")
                     .and_then(|v| v.as_str())
                     .unwrap_or("Tell me about yourself");
-                
+
                 // Since we can't directly access the transport from here,
                 // we'll just return a simple response
                 let content = vec![
@@ -65,27 +64,28 @@ async fn main() -> Result<()> {
                         text: format!("Question: {}", question),
                     },
                     ToolContent::Text {
-                        text: "This tool would normally use sampling to get an answer from an LLM.".to_string(),
-                    }
+                        text: "This tool would normally use sampling to get an answer from an LLM."
+                            .to_string(),
+                    },
                 ];
-                
+
                 let result = ToolCallResult {
                     content,
-                    is_error: Some(false)
+                    is_error: Some(false),
                 };
-                
+
                 Ok(result)
-            }
+            },
         )
         .build()?;
-    
+
     info!("Server initialized. Waiting for client connection...");
-    
+
     debug!("Starting server run loop");
     // Run server (blocks until shutdown)
     server.run().await?;
-    
+
     info!("Server shutting down");
-    
+
     Ok(())
 }

--- a/examples/simple-client/Cargo.toml
+++ b/examples/simple-client/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-client = { path = "../../mcp-client" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -1,43 +1,47 @@
-use std::sync::Arc;
 use anyhow::Result;
-use mcp_client::{ClientBuilder, transport::StdioTransport};
+use modelcontextprotocol_client::{transport::StdioTransport, ClientBuilder};
 use serde_json::json;
-use tracing::{info, Level};
 use std::fs::OpenOptions;
-use tracing_subscriber::fmt;
 use std::io;
+use std::sync::Arc;
+use tracing::{info, Level};
+use tracing_subscriber::fmt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging to a file
-    
+
     // Setup subscriber with file writer - no ANSI colors for file
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .with_writer(move || -> Box<dyn io::Write> {
-            Box::new(io::BufWriter::new(OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("simple-client.log")
-                .unwrap()))
+            Box::new(io::BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open("simple-client.log")
+                    .unwrap(),
+            ))
         })
         .with_ansi(true) // Enable ANSI color codes
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set default tracing subscriber");
-    
+
     info!("Starting simple MCP client");
-    
+
     // Path to the server executable
     let server_path = "../../target/debug/hello-world";
-    
+
     // Create and connect to server
     let (transport, mut receiver) = StdioTransport::new(server_path, vec![]);
-    
-    let client = Arc::new(ClientBuilder::new("simple-client", "0.1.0")
-        .with_transport(transport)
-        .build()?);
-    
+
+    let client = Arc::new(
+        ClientBuilder::new("simple-client", "0.1.0")
+            .with_transport(transport)
+            .build()?,
+    );
+
     // Start message handling
     let client_for_handler = client.clone();
     tokio::spawn(async move {
@@ -49,34 +53,48 @@ async fn main() -> Result<()> {
             }
         }
     });
-    
+
     // Initialize the client
     info!("Initializing connection to server");
     let init_result = client.initialize().await?;
-    info!("Connected to: {} v{}", init_result.server_info.name, init_result.server_info.version);
-    
+    info!(
+        "Connected to: {} v{}",
+        init_result.server_info.name, init_result.server_info.version
+    );
+
     // List available tools
     info!("Requesting available tools");
     let tools = client.list_tools().await?;
     info!("Available tools: {}", tools.tools.len());
     for tool in &tools.tools {
-        info!("Tool: {} - {}", tool.name, tool.description.as_deref().unwrap_or(""));
+        info!(
+            "Tool: {} - {}",
+            tool.name,
+            tool.description.as_deref().unwrap_or("")
+        );
     }
-    
+
     // Call the hello tool
     if tools.tools.iter().any(|t| t.name == "hello") {
         info!("Calling 'hello' tool");
-        let result = client.call_tool("hello", &json!({
-            "name": "MCP User"
-        })).await?;
-        
+        let result = client
+            .call_tool(
+                "hello",
+                &json!({
+                    "name": "MCP User"
+                }),
+            )
+            .await?;
+
         // Display the result
         info!("Tool result:");
         for content in result.content {
             match content {
-                mcp_protocol::types::tool::ToolContent::Text { text } => {
+                modelcontextprotocol_client::mcp_protocol::types::tool::ToolContent::Text {
+                    text,
+                } => {
                     info!("{}", text);
-                },
+                }
                 _ => {
                     info!("Received non-text content");
                 }
@@ -85,10 +103,10 @@ async fn main() -> Result<()> {
     } else {
         info!("'hello' tool not available");
     }
-    
+
     // Shutdown
     info!("Shutting down client");
     client.shutdown().await?;
-    
+
     Ok(())
 }

--- a/examples/template-client/Cargo.toml
+++ b/examples/template-client/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-client = { path = "../../mcp-client" }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/examples/template-client/src/main.rs
+++ b/examples/template-client/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use mcp_client::{transport::StdioTransport, ClientBuilder};
-use mcp_protocol::types::{resource::ResourceTemplatesListParams, tool::ToolContent};
+use modelcontextprotocol_client::mcp_protocol::types::{
+    resource::ResourceTemplatesListParams, tool::ToolContent,
+};
+use modelcontextprotocol_client::{transport::StdioTransport, ClientBuilder};
 use serde_json::json;
 use std::fs::OpenOptions;
 use std::io;
@@ -66,7 +68,11 @@ async fn main() -> Result<()> {
         .send_request("resources/list", None, "list_resources".to_string())
         .await?;
 
-    if let mcp_protocol::messages::JsonRpcMessage::Response { result, .. } = resources_result {
+    if let modelcontextprotocol_client::mcp_protocol::messages::JsonRpcMessage::Response {
+        result,
+        ..
+    } = resources_result
+    {
         if let Some(result) = result {
             info!("Resources: {}", result);
         }
@@ -84,7 +90,11 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    if let mcp_protocol::messages::JsonRpcMessage::Response { result, .. } = templates_result {
+    if let modelcontextprotocol_client::mcp_protocol::messages::JsonRpcMessage::Response {
+        result,
+        ..
+    } = templates_result
+    {
         if let Some(result) = result {
             info!("Templates: {}", result);
         }
@@ -92,11 +102,11 @@ async fn main() -> Result<()> {
 
     // Get completions for a template parameter
     info!("Requesting completions for database parameter");
-    let completion_params = mcp_protocol::types::completion::CompletionCompleteParams {
-        r#ref: mcp_protocol::types::completion::CompletionReference::Resource {
+    let completion_params = modelcontextprotocol_client::mcp_protocol::types::completion::CompletionCompleteParams {
+        r#ref: modelcontextprotocol_client::mcp_protocol::types::completion::CompletionReference::Resource {
             uri: "db:///{database}/{table}/{id}".to_string(),
         },
-        argument: mcp_protocol::types::completion::CompletionArgument {
+        argument: modelcontextprotocol_client::mcp_protocol::types::completion::CompletionArgument {
             name: "database".to_string(),
             value: "".to_string(),
         },
@@ -110,7 +120,11 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    if let mcp_protocol::messages::JsonRpcMessage::Response { result, .. } = completion_result {
+    if let modelcontextprotocol_client::mcp_protocol::messages::JsonRpcMessage::Response {
+        result,
+        ..
+    } = completion_result
+    {
         if let Some(result) = result {
             info!("Completions: {}", result);
         }

--- a/examples/template-server/Cargo.toml
+++ b/examples/template-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mcp-protocol = { path = "../../mcp-protocol" }
 modelcontextprotocol-server = { path = "../../mcp-server" }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/mcp-client/src/lib.rs
+++ b/mcp-client/src/lib.rs
@@ -4,3 +4,5 @@ pub mod transport;
 
 pub use client::{Client, ClientBuilder};
 pub use transport::Transport;
+
+pub use mcp_protocol;

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -11,3 +11,5 @@ pub mod sampling;
 
 pub use server::{Server, ServerBuilder};
 pub use transport::Transport;
+
+pub use mcp_protocol;


### PR DESCRIPTION
I was unable to compile the workspace because:

- the examples depended on the local workspace version of the mcp-protocol crate
- the server/client methods expected to receive mcp-protocol types from a pinned version of the crate (0.2.1)

The easiest way to resolve this was just to expose the internal mcp_protocol namespace from the client and server crates and use that in the examples.

Not sure if this is how you want to solve the problem, but I thought I should at least offer it back.